### PR TITLE
Register parent termination signal in child processes

### DIFF
--- a/src/stress.c
+++ b/src/stress.c
@@ -28,6 +28,7 @@
 #include <signal.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/prctl.h>
 #include <sys/wait.h>
 #include "config.h"
 
@@ -296,6 +297,8 @@ main (int argc, char **argv)
           switch (pid = fork ())
             {
             case 0:            /* child */
+              if (prctl(PR_SET_PDEATHSIG, SIGTERM) == -1)
+                exit(0);
               alarm (timeout);
               usleep (backoff);
               if (do_dryrun)
@@ -317,6 +320,8 @@ main (int argc, char **argv)
           switch (pid = fork ())
             {
             case 0:            /* child */
+              if (prctl(PR_SET_PDEATHSIG, SIGTERM) == -1)
+                exit(0);
               alarm (timeout);
               usleep (backoff);
               if (do_dryrun)
@@ -337,6 +342,8 @@ main (int argc, char **argv)
           switch (pid = fork ())
             {
             case 0:            /* child */
+              if (prctl(PR_SET_PDEATHSIG, SIGTERM) == -1)
+                exit(0);
               alarm (timeout);
               usleep (backoff);
               if (do_dryrun)
@@ -358,6 +365,8 @@ main (int argc, char **argv)
           switch (pid = fork ())
             {
             case 0:            /* child */
+              if (prctl(PR_SET_PDEATHSIG, SIGTERM) == -1)
+                exit(0);
               alarm (timeout);
               usleep (backoff);
               if (do_dryrun)


### PR DESCRIPTION
When the parent process terminates due to some signal, the child processes should follow. Use prctl() to set parent death signal to SIGTERM.

Signed-off-by: Vratislav Bendel <vbendel@redhat.com>

======================================================================
Also resolves https://bugs.launchpad.net/ubuntu/+source/stress/+bug/1335541

Builds and tests OK:
~~~
### BUILD ###

[root@localhost stress]# make
make  all-recursive
make[1]: Entering directory '/root/devel-stress/stress'
Making all in src
make[2]: Entering directory '/root/devel-stress/stress/src'
gcc -DHAVE_CONFIG_H -I. -I..    -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -g -O2 -MT stress.o -MD -MP -MF .deps/stress.Tpo -c -o stress.o stress.c
mv -f .deps/stress.Tpo .deps/stress.Po
gcc -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -g -O2   -o stress stress.o -lm 
make[2]: Leaving directory '/root/devel-stress/stress/src'
Making all in test
make[2]: Entering directory '/root/devel-stress/stress/test'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/root/devel-stress/stress/test'
make[2]: Entering directory '/root/devel-stress/stress'
make[2]: Leaving directory '/root/devel-stress/stress'
make[1]: Leaving directory '/root/devel-stress/stress'


### TEST ###

[root@localhost stress]# ./src/stress -c 1 -m 1 -i 1 -d 1 &
[1] 20834
[root@localhost stress]# stress: info: [20834] dispatching hogs: 1 cpu, 1 io, 1 vm, 1 hdd

[root@localhost stress]# ps
    PID TTY          TIME CMD
   9839 pts/2    00:00:00 bash
  20834 pts/2    00:00:00 stress
  20835 pts/2    00:00:01 stress
  20836 pts/2    00:00:00 stress
  20837 pts/2    00:00:01 stress
  20838 pts/2    00:00:01 stress
  20840 pts/2    00:00:00 ps
[root@localhost stress]# kill 20834
[root@localhost stress]# ps
    PID TTY          TIME CMD
   9839 pts/2    00:00:00 bash
  20842 pts/2    00:00:00 ps
[1]+  Terminated              ./src/stress -c 1 -m 1 -i 1 -d 1
[root@localhost stress]#
~~~