### PR TITLE
Check for sys/prctl.h availibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
 # Checks for header files.
-AC_CHECK_HEADERS([stdlib.h string.h unistd.h])
+AC_CHECK_HEADERS([stdlib.h string.h unistd.h sys/prctl.h])
 
 # Checks for library functions.
 AC_FUNC_FORK


### PR DESCRIPTION
NOTE: Updated the patch to omit the conflicts with `0448cfa Re-organized via astyle command`.

Tested as per https://github.com/Homebrew/homebrew-core/pull/120878

Commit message:
============================================
Non-Linux architectures don't provide <sys/prctl.h>. Fix compilation issues on other archs by checking for it's availibility and wrap related code in #ifdefs.

Fixes: https://github.com/resurrecting-open-source-projects/stress/issues/3

Signed-off-by: Vratislav Bendel <vbendel@redhat.com>

