### PR TITLE
drop useless malloc configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,6 @@ AC_CHECK_HEADERS([stdlib.h string.h unistd.h sys/prctl.h])
 
 # Checks for library functions.
 AC_FUNC_FORK
-AC_FUNC_MALLOC
 AC_CHECK_FUNCS([alarm sqrt strerror])
 
 # Special functions


### PR DESCRIPTION
If the test were to fail due to cross-compilation it will rename malloc to rpl_malloc which comes from gnulib resulting in a linking failure, lets assume malloc simply works instead.