### PR TITLE
stress: use nanosleep() instead of usleep()

### DIFF
--- a/src/stress.c
+++ b/src/stress.c
@@ -266,9 +266,12 @@ main (int argc, char **argv)
     while ((forks = (do_cpu + do_io + do_vm + do_hdd)))
     {
         long long backoff, timeout = 0;
+        struct timespec b;
 
         /* Calculate the backoff value so we get good fork throughput.  */
         backoff = do_backoff * forks;
+        b.tv_sec = backoff / 1000000;
+        b.tv_nsec = (backoff % 1000000) * 1000;
         dbg (stdout, "using backoff sleep of %llius\n", backoff);
 
         /* If we are supposed to respect a timeout, calculate it.  */
@@ -304,7 +307,7 @@ main (int argc, char **argv)
             case 0:            /* child */
                 worker_init();
                 alarm (timeout);
-                usleep (backoff);
+                nanosleep (&b, NULL);
                 if (do_dryrun)
                     exit (0);
                 exit (hogcpu ());
@@ -326,7 +329,7 @@ main (int argc, char **argv)
             case 0:            /* child */
                 worker_init();
                 alarm (timeout);
-                usleep (backoff);
+                nanosleep (&b, NULL);
                 if (do_dryrun)
                     exit (0);
                 exit (hogio ());
@@ -347,7 +350,7 @@ main (int argc, char **argv)
             case 0:            /* child */
                 worker_init();
                 alarm (timeout);
-                usleep (backoff);
+                nanosleep (&b, NULL);
                 if (do_dryrun)
                     exit (0);
                 exit (hogvm (do_vm_bytes, do_vm_stride, do_vm_hang, do_vm_keep));
@@ -368,7 +371,7 @@ main (int argc, char **argv)
             case 0:            /* child */
                 worker_init();
                 alarm (timeout);
-                usleep (backoff);
+                nanosleep (&b, NULL);
                 if (do_dryrun)
                     exit (0);
                 exit (hoghdd (do_hdd_bytes));


### PR DESCRIPTION
The docs mention that usleep() is obsolete in newer POSIX specs. And nanosleep() should be used.

It's not clear whether there is any libc out there that actually removed usleep().
In my case, I just maintain stress (and stress-ng) in OpenWrt and this patch is in our tree for a while:
  https://github.com/openwrt/packages/blob/3218dd24577b051fddb1635a5a856fe8426ef8f8/utils/stress/patches/010-usleep.patch

Refs:
  https://man7.org/linux/man-pages/man3/usleep.3.html

   4.3BSD, POSIX.1-2001.  POSIX.1-2001 declares this function
   obsolete; use nanosleep(2) instead.  POSIX.1-2008 removes the
   specification of usleep().

Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>